### PR TITLE
Default ft parent brand applied

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or update:
 
 ## Running
 
-`$GOPATH/bin/v1-brands-transformer --bertha-service-url={bertha url} --tme-username={tme-username} --port={port} --tme-password={tme-password} --token={tme-token} --base-url={base-url for the app} --tme-base-url={tme-base-url} --maxRecords={maxRecords} --batchSize={batchSize} --cache-file-name={cache-file-name}`
+`$GOPATH/bin/v1-brands-transformer --bertha-source-url={bertha url} --tme-username={tme-username} --port={port} --tme-password={tme-password} --token={tme-token} --base-url={base-url for the app} --tme-base-url={tme-base-url} --maxRecords={maxRecords} --batchSize={batchSize} --cache-file-name={cache-file-name}`
 
 TME credentials are mandatory and can be found in lastpass
 
@@ -25,7 +25,7 @@ TME credentials are mandatory and can be found in lastpass
 
 `docker build -t coco/v1-brands-transformer .`
 
-`docker run -ti --env BASE_URL=<base url> --env BERTHA_SERVICE_URL=<bertha url> --env TME_BASE_URL=<structure service url> --env TME_USERNAME=<user> --env TME_PASSWORD=<pass> --env TOKEN=<token> --env CACHE_FILE_NAME=<file> coco/v1-brands-transformer`
+`docker run -ti --env BASE_URL=<base url> --env BERTHA_SOURCE_URL=<bertha url> --env TME_BASE_URL=<structure service url> --env TME_USERNAME=<user> --env TME_PASSWORD=<pass> --env TOKEN=<token> --env CACHE_FILE_NAME=<file> coco/v1-brands-transformer`
 
 ## Endpoints
 

--- a/brands/model.go
+++ b/brands/model.go
@@ -22,6 +22,7 @@ type brand struct {
 	Description            string                 `json:"description,omitempty"`
 	DescriptionXML         string                 `json:"descriptionXML,omitempty"`
 	ImageURL               string                 `json:"_imageUrl,omitempty"`
+
 }
 
 type alternativeIdentifiers struct {

--- a/brands/model.go
+++ b/brands/model.go
@@ -22,7 +22,6 @@ type brand struct {
 	Description            string                 `json:"description,omitempty"`
 	DescriptionXML         string                 `json:"descriptionXML,omitempty"`
 	ImageURL               string                 `json:"_imageUrl,omitempty"`
-
 }
 
 type alternativeIdentifiers struct {

--- a/brands/service.go
+++ b/brands/service.go
@@ -324,7 +324,11 @@ func (s *brandServiceImpl) processBrands(c <-chan []brand, wg *sync.WaitGroup) {
 				return fmt.Errorf("Cache bucket [%v] not found!", cacheBucket)
 			}
 			for _, anBrand := range brands {
+				if (anBrand.ParentUUID == "") {
+					anBrand.ParentUUID = financialTimesBrandUuid
+				}
 				marshalledBrand, err := json.Marshal(anBrand)
+
 				if err != nil {
 					return err
 				}
@@ -449,9 +453,7 @@ func berthaToBrand(a berthaBrand) (brand, error) {
 		altIds.TME = nil
 	}
 
-	if a.ParentUUID != "" {
-		a.ParentUUID = a.ParentUUID
-	} else {
+	if a.ParentUUID == "" {
 		a.ParentUUID = financialTimesBrandUuid
 	}
 

--- a/brands/service.go
+++ b/brands/service.go
@@ -16,7 +16,8 @@ import (
 )
 
 const (
-	cacheBucket = "brand"
+	cacheBucket             = "brand"
+	financialTimesBrandUuid = "dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54"
 )
 
 // BrandService - interface for retrieving v1 brands
@@ -382,7 +383,7 @@ func (s *brandServiceImpl) loadCuratedBrands(bBrands []berthaBrand) error {
 		for _, b := range bBrands {
 			cachedBrand := bucket.Get([]byte(b.UUID))
 			var a brand
-			if b.TmeIdentifier == "" && b.UUID != "dbb0bdae-1f0c-11e4-b0cb-b2227cce2b54" {
+			if b.TmeIdentifier == "" && b.UUID != financialTimesBrandUuid {
 				// We've put this check in because editorial sometimes forget the TME Identifier.
 				// The UUID is for the FT, which is a special case (no TME Identifier but we still want it)
 				log.Warnf("No TME Identifier, ignoring curated brand %s [%s]", b.PrefLabel, b.UUID)
@@ -417,7 +418,13 @@ func addBerthaInformation(a brand, b berthaBrand) (brand, error) {
 	a.UUID = b.UUID
 	a.PrefLabel = b.PrefLabel
 	a.Strapline = b.Strapline
-	a.ParentUUID = b.ParentUUID
+
+	if b.ParentUUID != "" {
+		a.ParentUUID = b.ParentUUID
+	} else {
+		a.ParentUUID = financialTimesBrandUuid
+	}
+
 	a.Description = plainDescription
 	a.DescriptionXML = b.DescriptionXML
 	a.ImageURL = b.ImageURL
@@ -440,6 +447,12 @@ func berthaToBrand(a berthaBrand) (brand, error) {
 
 	if a.TmeIdentifier == "" {
 		altIds.TME = nil
+	}
+
+	if a.ParentUUID != "" {
+		a.ParentUUID = a.ParentUUID
+	} else {
+		a.ParentUUID = financialTimesBrandUuid
 	}
 
 	p := brand{

--- a/brands/service.go
+++ b/brands/service.go
@@ -324,7 +324,7 @@ func (s *brandServiceImpl) processBrands(c <-chan []brand, wg *sync.WaitGroup) {
 				return fmt.Errorf("Cache bucket [%v] not found!", cacheBucket)
 			}
 			for _, anBrand := range brands {
-				if anBrand.ParentUUID == "" {
+				if anBrand.ParentUUID == ""  {
 					anBrand.ParentUUID = financialTimesBrandUuid
 				}
 				marshalledBrand, err := json.Marshal(anBrand)
@@ -423,10 +423,10 @@ func addBerthaInformation(a brand, b berthaBrand) (brand, error) {
 	a.PrefLabel = b.PrefLabel
 	a.Strapline = b.Strapline
 
-	if b.ParentUUID != "" {
-		a.ParentUUID = b.ParentUUID
-	} else {
+	if b.ParentUUID == "" && b.UUID != financialTimesBrandUuid{
 		a.ParentUUID = financialTimesBrandUuid
+	} else {
+		a.ParentUUID = b.ParentUUID
 	}
 
 	a.Description = plainDescription
@@ -453,7 +453,7 @@ func berthaToBrand(a berthaBrand) (brand, error) {
 		altIds.TME = nil
 	}
 
-	if a.ParentUUID == "" {
+	if a.ParentUUID == "" && a.UUID != financialTimesBrandUuid{
 		a.ParentUUID = financialTimesBrandUuid
 	}
 

--- a/brands/service.go
+++ b/brands/service.go
@@ -324,7 +324,7 @@ func (s *brandServiceImpl) processBrands(c <-chan []brand, wg *sync.WaitGroup) {
 				return fmt.Errorf("Cache bucket [%v] not found!", cacheBucket)
 			}
 			for _, anBrand := range brands {
-				if (anBrand.ParentUUID == "") {
+				if anBrand.ParentUUID == "" {
 					anBrand.ParentUUID = financialTimesBrandUuid
 				}
 				marshalledBrand, err := json.Marshal(anBrand)


### PR DESCRIPTION
Unless otherwise specified a brand should have the parent brand uuid of FT so that we always add FT annotations to content